### PR TITLE
Added the multiarch prefix to build target dir.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 set(NAME gala-alternate-alt-tab)
 cmake_minimum_required (VERSION 2.8)
 cmake_policy (VERSION 2.8)
@@ -31,7 +30,7 @@ OPTIONS
 add_library(${NAME} SHARED ${VALA_C})
 target_link_libraries(${NAME} ${DEPS_LIBRARY} m)
 
-install(TARGETS ${NAME} DESTINATION lib/gala/plugins)
+install(TARGETS ${NAME} DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE}/gala/plugins)
 
 include(GSettings)
 add_schema("data/org.pantheon.desktop.gala.plugins.alternate-alt-tab.gschema.xml")


### PR DESCRIPTION
Hey @tom95 
I added a PPA with daily builds of the plugin, the only thing we're missing is a minor path change in cmake build target directory.

Please take a look, thanks.

Btw, the new PPA is at:
https://launchpad.net/~sushkov/+archive/ubuntu/libgala-alternate-alt-tab
There's a mirrored branch on ~lp at:
https://code.launchpad.net/~sushkov/+junk/gala-alternate-alt-tab
And the recipe uses this branch for package builds:
https://code.launchpad.net/~sushkov/+junk/gala-alternate-alt-tab-packaging

Feel free to include it in the readme.